### PR TITLE
fix: Error: Should not import the named export 'version'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
-{
-  "name": "ignews",
-  "private": true,
-  "version": "0.1.0",
+{ 
+    "name": "ignews",
+    "private": true,
+    "version": "0.1.0",
+ 
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -1,5 +1,5 @@
 import Stripe from 'stripe'
-import { version } from '../../package.json'
+import * as packageInfo from '../../package.json'
 
 export const stripe = new Stripe(
   process.env.STRIPE_API_KEY,
@@ -7,7 +7,7 @@ export const stripe = new Stripe(
     apiVersion: '2020-08-27',
     appInfo: {
       name: 'Ignews',
-      version
+      version: packageInfo.version,
     }
   }
 )


### PR DESCRIPTION
Error: Should not import the named export 'version' (imported as 'version')